### PR TITLE
chore(@atlantis-lab/tinkoff-api): set version to 0.0.0

### DIFF
--- a/packages/tinkoff-api/package.json
+++ b/packages/tinkoff-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atlantis-lab/tinkoff-api",
-  "version": "0.0.1-pre-alpha.6",
+  "version": "0.0.0",
   "main": "dist/index.js",
   "source": "src/index.ts",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
affects: @atlantis-lab/tinkoff-api