### PR TITLE
chore(deps): move rimraf from deps to devDeps

### DIFF
--- a/packages/tinkoff-api/package.json
+++ b/packages/tinkoff-api/package.json
@@ -15,12 +15,12 @@
     "access": "public"
   },
   "dependencies": {
-    "node-fetch": "2.6.1",
-    "rimraf": "3.0.2"
+    "node-fetch": "2.6.1"
   },
   "devDependencies": {
     "@types/node": "13.13.38",
     "@types/node-fetch": "2.5.7",
-    "typescript": "4.1.3"
+    "typescript": "4.1.3",
+    "rimraf": "3.0.2"
   }
 }


### PR DESCRIPTION
affects: @atlantis-lab/tinkoff-api